### PR TITLE
chore(ci): enable nvidia builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image_flavor: [-main]
+        image_flavor: [-main, -nivida]
         base_name: [surface]
         base_image_name: [silverblue, kinoite, vauxite, sericea, base, lxqt, mate]
         major_version: [38]


### PR DESCRIPTION
In the process of moving builds around, nvidia got probably accidentally removed and should stay here in the matrix if i'm correct.