### PR TITLE
fix(f39): Build from main instead of nokmods

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image_flavor: [-main]
+        image_flavor: [-nokmods, -main]
         base_name: [surface]
         base_image_name: [silverblue, kinoite, vauxite, sericea, base, lxqt, mate]
         major_version: [38]
@@ -32,6 +32,13 @@ jobs:
           - major_version: 38
             is_latest_version: true
             is_stable_version: true
+        exclude:
+          - image_flavor: -nokmods
+            major_version: 39
+          - image_flavor: -main
+            major_version: 38
+          - image_flavor: -main
+            major_version: 37
     steps:
       - name: Maximize build space
         uses: ublue-os/remove-unwanted-software@v6
@@ -43,7 +50,7 @@ jobs:
       - name: Matrix Variables
         run: |
           echo "BASE_IMAGE_NAME=${{ matrix.base_image_name }}" >> $GITHUB_ENV
-          if [[ "${{ matrix.image_flavor }}" =~ "main" ]]; then
+          if [[ "${{ matrix.image_flavor }}" =~ "nokmods" || "${{ matrix.image_flavor }}" =~ "main" ]]; then
               echo "IMAGE_NAME=${{ format('{0}-{1}', matrix.base_image_name, matrix.base_name) }}" >> $GITHUB_ENV
           else
               echo "IMAGE_NAME=${{ format('{0}-{1}{2}', matrix.base_image_name, matrix.base_name, matrix.image_flavor) }}" >> $GITHUB_ENV

--- a/Containerfile
+++ b/Containerfile
@@ -23,14 +23,11 @@ RUN wget https://pkg.surfacelinux.com/fedora/linux-surface.repo -P /etc/yum.repo
     rpm-ostree cliwrap install-to-root / && \
     rpm-ostree override replace /tmp/surface-kernel.rpm \
         --remove kernel-core \
-        --remove kernel-devel-matched \
         --remove kernel-modules \
         --remove kernel-modules-extra \
         --remove libwacom \
         --remove libwacom-data \
         --install kernel-surface \
-        --install kernel-surface-devel \
-        --install kernel-surface-devel-matched \
         --install iptsd \
         --install libwacom-surface \
         --install libwacom-surface-data


### PR DESCRIPTION
nokmods is deprecated from Fedora 39 onward