### PR TITLE
feat(ci): Sign kernel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,6 +152,15 @@ jobs:
           extra-args: |
             --target=${{ matrix.base_name }}
 
+      # Sign kernel with akmods key pair
+      - name: Sign kernel
+        uses: EyeCantCU/kernel-signer@v0.1.1
+        with:
+          image: ${{ steps.build_image.outputs.image }}
+          privkey: ${{ secrets.AKMOD_PRIVKEY_20230518 }}
+          pubkey: /etc/pki/akmods/certs/akmods-ublue.der
+          tags: ${{ steps.build_image.outputs.tags }}
+
       # Workaround bug where capital letters in your GitHub username make it impossible to push to GHCR.
       # https://github.com/macbre/push-to-ghcr/issues/12
       - name: Lowercase Registry


### PR DESCRIPTION
Uses the same key pair utilized by akmods to sign the kernel, allowing for the usage of Secure Boot after the key has been enrolled.