### PR TITLE
chore(ci): Bump kernel signer to v0.1.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,7 +154,7 @@ jobs:
 
       # Sign kernel with akmods key pair
       - name: Sign kernel
-        uses: EyeCantCU/kernel-signer@v0.1.1
+        uses: EyeCantCU/kernel-signer@v0.1.2
         with:
           image: ${{ steps.build_image.outputs.image }}
           privkey: ${{ secrets.AKMOD_PRIVKEY_20230518 }}


### PR DESCRIPTION
Addresses an issue where not all tags are signed